### PR TITLE
fix(a11y): corrections mineures sur footer et documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,28 @@ Le projet fera l’objet :
 *Mise à jour - 5 novembre 2025*
 
 ---
+
+### Issue #3 - Footer commun
+
+- Création du composant `Footer.jsx` :
+  - Structure en 3 colonnes (coordonnées, liens utiles, réalisations)
+  - Intégration des icônes Bootstrap (GitHub, Twitter, LinkedIn)
+  - Liens internes gérés via `NavLink` de React Router DOM
+  - Application de classes utilitaires Bootstrap pour la mise en page responsive
+  - Gestion du hover sur les icônes sociales
+- Ajustement du layout global (`global.css`) :
+  - Mise en place du `display: flex` et `min-height: 100vh` sur `#root`
+  - Alignement du footer en bas de page (sticky footer)
+  - Harmonisation des paddings horizontaux
+- Ajustement léger de la Navbar :
+  - Suppression du `fs-bold` sur le logo textuel
+  - Ajustement des paddings horizontaux
+
+### Correctif mineur
+
+- Correction de l'attribut `rel="noopener noreferrer"` pour les liens externes
+- Documentation mise à jour (`README.md`)
+
+  *Mise à jour - 6 novembre 2025*
+
+---

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -19,7 +19,7 @@ export default function Footer() {
               href="https://github.com/"
               className="text-secondary me-3"
               target="_blank"
-              rel="nooperner noreferrer"
+              rel="noopener noreferrer"
               aria-label="Lien vers le profil GitHub"
               title="GitHub">
                 <i className="bi bi-github fs-4" aria-hidden="true"></i>
@@ -28,7 +28,7 @@ export default function Footer() {
               href="https://x.com/"
               className="text-secondary me-3"
               target="_blank"
-              rel="nooperner noreferrer"
+              rel="noopenner noreferrer"
               aria-label="Lien vers le profil Twitter"
               title="Twitter">
                 <i className="bi bi-twitter fs-4" aria-hidden="true"></i>
@@ -37,7 +37,7 @@ export default function Footer() {
               href="https://linkedin.com/"
               className="text-secondary"
               target="_blank"
-              rel="nooperner noreferrer"
+              rel="noopener noreferrer"
               aria-label="Lien vers le profil LinkedIn"
               title="LinkedIn">
                 <i className="bi bi-linkedin fs-4" aria-hidden="true"></i>


### PR DESCRIPTION
## Correctif mineur
Petite mise à jour suite à la fermeture de l'issue #3 .

### ℹ️ Détails
- Correction de l’attribut `rel="noopener noreferrer"` sur les liens externes (a11y)
- Mise à jour du fichier `README.md`

### 📎 Issue liée :
_Rattachement post-merge de l’issue #3 (Footer structure + interactions)_